### PR TITLE
Fallthrough for non-ansible yaml files

### DIFF
--- a/company-ansible.el
+++ b/company-ansible.el
@@ -43,7 +43,7 @@
 
   (cl-case command
     (interactive (company-begin-backend 'company-ansible))
-    (prefix (and (eq major-mode 'yaml-mode)
+    (prefix (and (bound-and-true-p ansible)
                  (company-grab-word)))
 
     (candidates


### PR DESCRIPTION
Not all .yaml files are ansible files. 

This PR makes it so that this backend is used only when ansible mode is active.