### PR TITLE
Fix completion for keywords that contain two words

### DIFF
--- a/company-ansible.el
+++ b/company-ansible.el
@@ -44,7 +44,7 @@
   (cl-case command
     (interactive (company-begin-backend 'company-ansible))
     (prefix (and (bound-and-true-p ansible)
-                 (company-grab-word)))
+                 (company-grab-symbol)))
 
     (candidates
      (cl-remove-if-not


### PR DESCRIPTION
When invoking `company-ansible` on `get_|` no candidates are returned. I'd expect that  candidates should be `get_url`, `get_certificate` etc.